### PR TITLE
Added a configuration for OSX

### DIFF
--- a/projects/VSCode/.vscode/c_cpp_properties.json
+++ b/projects/VSCode/.vscode/c_cpp_properties.json
@@ -17,6 +17,27 @@
             "cStandard": "c11",
             "cppStandard": "c++14",
             "intelliSenseMode": "clang-x64"
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "<path_to_raylib>/src/**",
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE",
+                "GRAPHICS_API_OPENGL_33",
+                "PLATFORM_DESKTOP"
+            ],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "clang-x64"
         }
     ],
     "version": 4


### PR DESCRIPTION
This requires the user to explicitly specify the path to their raylib folder. We need a better way around this (something like what we do for windows would help).